### PR TITLE
Fix missing `=` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ if !output.status.success() {
 - Providing cargo with the required linker flags:
 ```rust
 println!(
-    "cargo:rustc-link-search{}",
+    "cargo:rustc-link-search={}",
     project.library_dir().unwrap().to_str().unwrap()
 );
 println!(


### PR DESCRIPTION
This fixes a typo in one of the snippets in the README.